### PR TITLE
Dockerfile: Update php to 7.4.5-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.4-cli
+FROM php:7.4.5-cli
 
 LABEL maintainer "Nino Treyssat-Vincent <nino+docker@treyssatvincent.fr>"
 


### PR DESCRIPTION

Image **php** updated from 7.4.4-cli to 7.4.5-cli

**Image:** [php](https://hub.docker.com/r/library/php/)  
**Version:** 7.4.4-cli &rarr; 7.4.5-cli  
**Dockerfile:** Dockerfile  


If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=c5d4265a-5dee-4c31-8ad3-7b68a470550a).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	